### PR TITLE
Add CSS hot-realoading with css-hot-loader

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -183,7 +183,7 @@ module.exports = {
       // in development "style" loader enables hot editing of CSS.
       {
         test: /\.css$/,
-        use: ExtractTextPlugin.extract({
+        use: ['css-hot-loader'].concat(ExtractTextPlugin.extract({
         fallback: 'style-loader',
           use: [
             {
@@ -195,11 +195,11 @@ module.exports = {
             },
           'postcss-loader'
           ]
-        })
+        }))
       },
       {
         test: /\.scss$/,
-        use: ExtractTextPlugin.extract({
+        use: ['css-hot-loader'].concat(ExtractTextPlugin.extract({
         fallback: 'style-loader',
           use: [
             {
@@ -213,7 +213,7 @@ module.exports = {
             },
           'sass-loader'
           ]
-        })
+        }))
       },
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "file" loader exclusion list.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-runtime": "6.23.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
+    "css-hot-loader": "^1.3.5",
     "css-loader": "0.28.4",
     "dotenv": "4.0.0",
     "eslint": "3.19.0",


### PR DESCRIPTION
Hi again, here is a pull request that adds CSS hot-reloading to the DEV config.

Relates to the issue I had opened before to https://github.com/swanie21/sass-css-modules-webpack/issues/1